### PR TITLE
Fixed bash process PID 1

### DIFF
--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -54,5 +54,4 @@ then
     touch /.data_loaded
 fi
 
-virtuoso-t +wait +foreground
-
+exec virtuoso-t +wait +foreground


### PR DESCRIPTION
In order to get Docker to notify properly that Virtuoso needs to quit,
the PID of Virtuoso must be 1 or the process 1 must forward the signal
to the virtuoso database.

In the previous situation, /bin/bash was the PID 1 and it doesn't
forward the signal by default. It is easier and always best to simply
let your main process to be the PID 1 when using Docker.

`exec` is a command that replace the current process by another one.