### PR TITLE
update virutoso.ini

### DIFF
--- a/virtuoso.ini
+++ b/virtuoso.ini
@@ -64,9 +64,9 @@ CheckpointAuditTrail		= 0
 AllowOSCalls			= 0
 SchedulerInterval		= 10
 DirsAllowed			= ., /usr/local/virtuoso-opensource/share/virtuoso/vad
-ThreadCleanupInterval		= 0
+ThreadCleanupInterval		= 10
 ThreadThreshold			= 10
-ResourcesCleanupInterval	= 0
+ResourcesCleanupInterval	= 10
 FreeTextBatchSize		= 100000
 SingleCPU			= 0
 VADInstallDir			= /usr/local/virtuoso-opensource/share/virtuoso/vad/
@@ -246,9 +246,9 @@ DeferInferenceRulesInit    	= 0  ; controls inference rules loading
 
 [Plugins]
 LoadPath			= /usr/local/virtuoso-opensource/lib/virtuoso/hosting
-Load1				= plain, wikiv
-Load2				= plain, mediawiki
-Load3				= plain, creolewiki
+;Load1				= plain, wikiv
+;Load2				= plain, mediawiki
+;Load3				= plain, creolewiki
 ;Load4			= plain, im
 ;Load5		= plain, wbxml2
 ;Load6			= plain, hslookup


### PR DESCRIPTION
- removed loading of useless plugins
- set auto cleanup of threads and resources to 10 minutes (cfr. http://docs.openlinksw.com/virtuoso/dbadm/)