### PR TITLE
Properly handle config items with spaces

### DIFF
--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -20,9 +20,9 @@ then
     key=`echo "$setting" | grep -o -P "_[^_]+=" | sed 's/[_=]//g'`
     value=`echo "$setting" | grep -o -P "=.*$" | sed 's/^=//g'`
     echo "Registering $section[$key] to be $value"
-    crudini --set virtuoso.ini $section $key $value
+    crudini --set virtuoso.ini $section $key "$value"
   done
-  echo `date +%Y-%m%-dT%H:%M:%S%:z` >  .config_set
+  echo "`date +%Y-%m%-dT%H:%M:%S%:z`" >  .config_set
   echo "Finished converting environment variables to ini file"
 fi
 
@@ -32,8 +32,8 @@ then
   if [ "$DBA_PASSWORD" ]; then echo "user_set_password('dba', '$DBA_PASSWORD');" >> /sql-query.sql ; fi
   if [ "$SPARQL_UPDATE" = "true" ]; then echo "GRANT SPARQL_UPDATE to \"SPARQL\";" >> /sql-query.sql ; fi
   virtuoso-t +wait && isql-v -U dba -P dba < /dump_nquads_procedure.sql && isql-v -U dba -P dba < /sql-query.sql
-  kill $(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')
-  echo `date +%Y-%m-%dT%H:%M:%S%:z` >  .dba_pwd_set
+  kill "$(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')"
+  echo "`date +%Y-%m-%dT%H:%M:%S%:z`" >  .dba_pwd_set
 fi
 
 if [ ! -f ".data_loaded" -a -d "toLoad" ] ;
@@ -50,8 +50,8 @@ then
     echo "WAIT_FOR_CHILDREN; " >> /load_data.sql
     echo "$(cat /load_data.sql)"
     virtuoso-t +wait && isql-v -U dba -P "$pwd" < /load_data.sql
-    kill $(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')
-    echo `date +%Y-%m-%dT%H:%M:%S%:z` > .data_loaded
+    kill "$(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')"
+    echo "`date +%Y-%m-%dT%H:%M:%S%:z`" > .data_loaded
 fi
 
 exec virtuoso-t +wait +foreground

--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -50,7 +50,7 @@ then
     echo "WAIT_FOR_CHILDREN; " >> /load_data.sql
     echo "$(cat /load_data.sql)"
     virtuoso-t +wait && isql-v -U dba -P "$pwd" < /load_data.sql
-    kill "$(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')"
+    kill $(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')
     echo "`date +%Y-%m-%dT%H:%M:%S%:z`" > .data_loaded
 fi
 


### PR DESCRIPTION
Some configuration keys, such as `DirsAllowed` can contain spaces.
`virtuoso.sh` wasn't properly escaping the variables when writing them to the config file, leading to very weird errors.

The other changes are shellcheck suggestions to prevent similar whitespace issues in other places.