### PR TITLE
slim down docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,25 @@
 FROM ubuntu:16.04
 
-# Install Virtuoso prerequisites and crudini Python lib
-RUN apt-get update \
-        && apt-get install -y build-essential debhelper autotools-dev autoconf automake unzip wget net-tools git libtool flex bison gperf gawk m4 libssl-dev libreadline-dev libreadline-dev openssl python-pip \
-        && pip install crudini
-
 # Set Virtuoso commit SHA to Virtuoso 7.2.4 release (25/04/2016)
 ENV VIRTUOSO_COMMIT 96055f6a70a92c3098a7e786592f4d8ba8aae214
 
-# Get Virtuoso source code from GitHub and checkout specific commit
-# Make and install Virtuoso (by default in /usr/local/virtuoso-opensource)
-RUN git clone https://github.com/openlink/virtuoso-opensource.git \
-        && cd virtuoso-opensource \
-        && git checkout ${VIRTUOSO_COMMIT} \
+# Build virtuoso from source and clean up afterwards
+RUN apt-get update \
+        && apt-get install -y build-essential autotools-dev autoconf automake unzip wget net-tools libtool flex bison gperf gawk m4 libssl-dev libreadline-dev openssl crudini \
+        && wget https://github.com/openlink/virtuoso-opensource/archive/${VIRTUOSO_COMMIT}.zip \
+        && unzip ${VIRTUOSO_COMMIT}.zip \
+        && rm ${VIRTUOSO_COMMIT}.zip \
+        && cd virtuoso-opensource-${VIRTUOSO_COMMIT} \
         && ./autogen.sh \
-        && CFLAGS="-O2 -m64" && export CFLAGS && ./configure --disable-bpel-vad --enable-conductor-vad --enable-fct-vad --disable-dbpedia-vad --disable-demo-vad --disable-isparql-vad --disable-ods-vad --disable-sparqldemo-vad --disable-syncml-vad --disable-tutorial-vad --with-readline --program-transform-name="s/isql/isql-v/" \
+        && export CFLAGS="-O2 -m64" && ./configure --disable-bpel-vad --enable-conductor-vad --enable-fct-vad --disable-dbpedia-vad --disable-demo-vad --disable-isparql-vad --disable-ods-vad --disable-sparqldemo-vad --disable-syncml-vad --disable-tutorial-vad --with-readline --program-transform-name="s/isql/isql-v/" \
         && make && make install \
         && ln -s /usr/local/virtuoso-opensource/var/lib/virtuoso/ /var/lib/virtuoso \
-	&& ln -s /var/lib/virtuoso/db /data \
+        && ln -s /var/lib/virtuoso/db /data \
         && cd .. \
-        && rm -r /virtuoso-opensource
+        && rm -r /virtuoso-opensource-${VIRTUOSO_COMMIT} \
+        && apt remove --purge -y build-essential autotools-dev autoconf automake unzip wget net-tools libtool flex bison gperf gawk m4 libssl-dev libreadline-dev \
+        && apt autoremove -y \
+        && apt autoclean
 
 # Add Virtuoso bin to the PATH
 ENV PATH /usr/local/virtuoso-opensource/bin/:$PATH


### PR DESCRIPTION
reduced the docker image size from 606MB to 270MB
- remove dependencies only required for build
- use wget instead of git to speed up build of the docker image
- use stock crudini instead of pip installed version