### PR TITLE
Fix underscores in INI variables

### DIFF
--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -25,7 +25,7 @@ then
   printenv | grep -P "^VIRT_" | while read setting
   do
     section=`echo "$setting" | grep -o -P "^VIRT_[^_]+" | sed 's/^.\{5\}//g'`
-    key=`echo "$setting" | grep -o -P "_[^_]+=" | sed 's/[_=]//g'`
+    key=`echo "$setting" | sed -E 's/^VIRT_[^_]+_(.*)=.*$/\1/g'`
     value=`echo "$setting" | grep -o -P "=.*$" | sed 's/^=//g'`
     echo "Registering $section[$key] to be $value"
     crudini --set virtuoso.ini $section $key "$value"


### PR DESCRIPTION
For issue #17.

It was not possible to set these values via variables:
  - VIRT_Flags_tn_max_memory=2000000000
  - VIRT_Flags_hash_join_enable=2