### PR TITLE
Allow restoring a database from a backup when starting Virtuoso.

### DIFF
--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -39,7 +39,6 @@ then
     echo "Start restoring a backup"
     cd backupToRestore
     virtuoso-t +restore-backup $BACKUP_PREFIX +configfile /data/virtuoso.ini
-    kill $(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')
     echo "`date +%Y-%m-%dT%H:%M:%S%:z`" > .backup_restored
     cd /data
 fi

--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -34,6 +34,16 @@ then
   echo "Finished converting environment variables to ini file"
 fi
 
+if [ ! -f ".backup_restored" -a -d "backupToRestore" ] ;
+then
+    echo "Start restoring a backup"
+    cd backupToRestore
+    virtuoso-t +restore-backup $BACKUP_PREFIX +configfile /data/virtuoso.ini
+    kill $(ps aux | grep '[v]irtuoso-t' | awk '{print $2}')
+    echo "`date +%Y-%m-%dT%H:%M:%S%:z`" > .backup_restored
+    cd /data
+fi
+
 if [ ! -f ".dba_pwd_set" ];
 then
   touch /sql-query.sql


### PR DESCRIPTION
This adds the possibility to restore a database backup when spawning the container.
The only requirement is passing in the backup prefix: e.g.
docker run --name virtuoso
 -p 8890:8890 
 -p 1111:1111
 -e DBA_PASSWORD=dba
 -e SPARQL_UPDATE=true
 -e BACKUP_PREFIX=MY_PERFIX_
 --mount type=bind,source=/host/system/dir/virtuoso/db,target=/data
  -d tenforce/virtuoso

See http://docs.openlinksw.com/virtuoso/backup_recovery/#rstrfrmbckuponline