### PR TITLE
Make backup dir configurable

### DIFF
--- a/virtuoso.sh
+++ b/virtuoso.sh
@@ -34,10 +34,11 @@ then
   echo "Finished converting environment variables to ini file"
 fi
 
-if [ ! -f ".backup_restored" -a -d "backups" -a ! -z "$BACKUP_PREFIX" ] ;
+BACKUP_DIR=${BACKUP_DIR:-backups}
+if [ ! -f ".backup_restored" -a -d "$BACKUP_DIR" -a ! -z "$BACKUP_PREFIX" ] ;
 then
     echo "Start restoring a backup with prefix $BACKUP_PREFIX"
-    cd backups
+    cd $BACKUP_DIR
     virtuoso-t +restore-backup $BACKUP_PREFIX +configfile /data/virtuoso.ini
     if [ $? -eq 0 ]; then
         cd /data


### PR DESCRIPTION
## Problem

I have this case: I need to make container's `/data` dir a persistent/named volume in order to persist Virtuoso storage. For performance reasons I don't want to mount this dir in the host machine. I'm using this setup in `docker-compose.yml`:

```yaml
services:
  virtuoso:
    ...
    volumes:
      - source: virtuoso
        target: /data
        type: volume
        volume:
          nocopy: true
...
volumes:
  # Persistent Docker volume for Virtuoso data.
  virtuoso:
    name: virtuoso
```

But the container's `/data/backups` directory I want to mount on the host machine. Unfortunately, I this doesn't work:

```yaml
    volumes:
      - source: virtuoso
        target: /data
        type: volume
        volume:
          nocopy: true
      - ./.backups:/data/backups
```

See https://stackoverflow.com/questions/52137210/how-to-share-sub-folders-from-a-docker-named-volume why...

## Proposal

Allow to configure the backups directory via an environment variable.