### PR TITLE
Update Dockerfile to latest VOS Release, 7.2.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
-# Set Virtuoso commit SHA to Virtuoso 7.2.6.1 release (2021-06-22)
-ENV VIRTUOSO_COMMIT 64663f91c657aec14bbdcef8b6e5c9b6ac89cb8b
+# Set Virtuoso commit SHA to Virtuoso 7.2.9 release (2023-02-28)
+ENV VIRTUOSO_COMMIT 795af34a7287f064effd91ed251e6bb711f1f5ee
 
 # Build virtuoso from source and clean up afterwards
 RUN apt-get update \


### PR DESCRIPTION
Note that tenforce has not applied updates since 7.2.6.1, including —
* [`031118cc2953117da5f3e7f2e2d33050c7e177ae`](https://github.com/openlink/virtuoso-opensource/commit/031118cc2953117da5f3e7f2e2d33050c7e177ae) == 7.2.7
* [`64e6ecd39b03383875b7f2f15ed8070e2ebcd1f0`](https://github.com/openlink/virtuoso-opensource/commit/64e6ecd39b03383875b7f2f15ed8070e2ebcd1f0) == 7.2.8
* [`795af34a7287f064effd91ed251e6bb711f1f5ee`](https://github.com/openlink/virtuoso-opensource/commit/795af34a7287f064effd91ed251e6bb711f1f5ee) == 7.2.9

Increasingly inaccurate [tenforce/docker-virtuoso](https://github.com/tenforce/docker-virtuoso) `README` (last VOS version mentioned is 7.2.5) should be updated as well...